### PR TITLE
Update Azure Static Web Apps guide for .NET 8

### DIFF
--- a/doc/articles/guides/azure-static-webapps.md
+++ b/doc/articles/guides/azure-static-webapps.md
@@ -22,7 +22,7 @@ Here is how to publish an app from GitHub, using Uno Platform:
     dotnet new unoapp -o MyApp
     ```
 
-- If the `<TargetFramework>` value in the `MyApp.Wasm.csproj` is not `net5.0`, [follow the upgrading steps provided here](../../articles/migrating-from-previous-releases.md#migrating-webassembly-projects-to-net-5).
+- If the `<TargetFramework>` value in the `MyApp.Wasm.csproj` is not `net8.0`, [follow the upgrading steps provided here](../../articles/migrating-to-uno-5.md#migrating-webassembly-from-netstandard2-0-to-net7-0-or-net8-0).
 - If in the `MyApp.Wasm\wwwroot`, you find a `web.config` file, delete it. This will enable brotli compression in Azure Static Web Apps.
 - Search for [Static Web Apps](https://portal.azure.com/#create/Microsoft.StaticApp) in the Azure Portal
 - Fill the required fields in the creation form:
@@ -35,14 +35,14 @@ Here is how to publish an app from GitHub, using Uno Platform:
 
     ![visual-studio-installer-web](../Assets/aswa-settings.png)
 
-- The click on **Review+Create** button. Azure will automatically create a new **GitHub Actions Workflow** in your repository. The workflow will automatically be started and will fail for this first run, as some parameters need to be adjusted.
+- Then click on **Review+Create** button. Azure will automatically create a new **GitHub Actions Workflow** in your repository. The workflow will automatically be started and will fail for this first run, as some parameters need to be adjusted.
 - In your repository’s newly added github workflow (in `.github/workflows`), add the following two steps, after the checkout step:
 
     ```yaml
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v1.7.2
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '6.0.402'
+        dotnet-version: '8.0.100'
 
     - run: |
         cd src/MyApp.Wasm
@@ -52,7 +52,7 @@ Here is how to publish an app from GitHub, using Uno Platform:
 - In the Deploy step that was automatically added, change the `app_location` parameter to the following:
 
     ```yaml
-    app_location: "src/MyApp.Wasm/bin/Debug/net5.0/dist"
+    app_location: "src/MyApp.Wasm/bin/Debug/net8.0/dist"
     ```
 
 - Once changed, the application will be built and deployed on your Azure Static Web App instance.


### PR DESCRIPTION
## Summary
- reference `net8.0` instead of `net5.0`
- update GitHub Action snippet with a recent `setup-dotnet` version and .NET 8 SDK
- update `app_location` path for .NET 8
- fix wording around the Review+Create button
- point upgrade instructions to the migration guide section for WebAssembly

## Testing
- `npx markdownlint "doc/articles/guides/azure-static-webapps.md"` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686bcbc03f808331bf122bee2fb8a538